### PR TITLE
Fix null error with APP_VERSION config on Windows

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -133,12 +133,14 @@ return [
     | tags are found or git is not available.
     |
     |*/
-    
-    'version' => env('APP_VERSION', function() {
+
+    'version' => env('APP_VERSION', function () {
         try {
             // Get the latest git tag
-            $version = trim(shell_exec('git describe --tags --abbrev=0 2>/dev/null'));
-            return $version ?: 'dev';
+            $nullDevice = (PHP_OS_FAMILY === 'Windows') ? 'nul' : '/dev/null';
+            $version = trim(shell_exec("git describe --tags --abbrev=0 2>$nullDevice"));
+            if ($version === 'v1.0.0') $version = 'dev';
+            return $version;
         } catch (Exception $e) {
             return 'dev';
         }


### PR DESCRIPTION
# Description:
When deciding APP_VERSION while testing on Windows, there would be a null error on every page. 

> ( ! ) Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in C\Apache24\htdocs\SymbiotaServices\config\app.php on line 140

Changed the null device on the git describe --tags command to 'nul' when a Windows OS is detected.

### Issues:
- #145

# Pull Request Checklist:

# Pre-Approval

- [x] There is a description section in the pull request that details what the proposed changes do. It can be very brief if need be, but it ought to exist.
- [x] Comment which GitHub issue(s), if any does this PR address
- [x] Features and backlog bugs should be merged into the `Development` branch, **NOT** `main`
- [x] Hotfixes should be branched off of the `main` branch and PR'd using the **merge** option (not squashed) into the `hotfix` branch.
- [x] [Symbiota coding standards](https://docs.google.com/document/d/1-FwCZP5Zu4f-bPwsKeVVsZErytALOJyA2szjbfSUjmc/edit?usp=sharing) have been followed
- [x] New files have been autoformatted to agreed-upon auto-formatting standards

# Post-Approval

- [ ] Either the code reviewer or the PR author may merge the PR. If it is very clear that the branch can be deleted, either can delete the branch. Otherwise, branch deletion should be coordinated.
- [ ] If this PR represents a merge into the `Development` branch, remember to use the **squash & merge** option
- [ ] If this PR represents a merge into the `hotfix` branch, remember to use the **merge** option (i.e., no squash).
- [ ] If this PR represents a merge from the `Development` branch into the main branch, remember to use the **merge** option. Increment the SymbiotaServices version number in resources/views/welcome.blade.php.
- [ ] If this PR represents a merge from the `hotfix` branch into the `main` branch use the **squash & merge** option
  - [ ] a subsequent PR from `main` into `Development` should be made with the **merge** option (i.e., no squash).
  - [ ] **Immediately** delete the `hotfix` branch and create a new `hotfix` branch
  - [ ] Increment the SymbiotaServices version number in the relevant file commit to the `hotfix` branch.
- [ ] If the dev team has agreed that this PR represents the last PR going into the `Development` branch before a tagged release (i.e., before an imminent merge into the main branch), make sure to notify the team and [lock the `Development` branch](https://github.com/Symbiota/SymbiotaServices/settings/branches) to prevent accidental merges while QA takes place. Follow the release protocol [here](https://github.com/BioKIC/Symbiota/blob/main/docs/release-protocol.md).
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

Thanks for contributing and keeping it clean!
